### PR TITLE
Increase limit for research resources

### DIFF
--- a/app/Http/Controllers/researchController.php
+++ b/app/Http/Controllers/researchController.php
@@ -139,7 +139,8 @@ class researchController extends Controller
       $api->setArguments(
         $args = array(
             'fields' => '*.*.*.*',
-            'meta' => 'result_count,total_count,type',
+            'limit' => 100,
+            'meta' => '*',
             'sort' => 'id'
         )
       );


### PR DESCRIPTION
Increase to 100, not showing the most recently migrated resources